### PR TITLE
Fix serializing comment options beneficiaries

### DIFF
--- a/helpers/serializer.js
+++ b/helpers/serializer.js
@@ -47,7 +47,28 @@ const BooleanSerializer = (buffer, data) => {
 
 const StaticVariantSerializer = (itemSerializers) => {
   return (buffer, data) => {
-    const [id, item] = data
+    let id = data[0]
+    const item = data[1]
+    // id was/is supposed to be 0 or integer here but seems to have been changed in e.g. comment_options
+    // extensions: [
+    //   [
+    //     "comment_payout_beneficiaries",
+    //     {
+    //       "beneficiaries": [
+    //         {
+    //           "account": "vimm",
+    //           "weight": 1000
+    //         }
+    //       ]
+    //     }
+    //   ]
+    // ]
+    // "comment_payout_beneficiaries" was 0 and at some point it got changed
+    // It should still be serialized as a 0 or a integer
+    // Now the question is, always 0? will need an example transaction to prove otherwise
+    if (typeof id === 'string') {
+      id = 0
+    }
     buffer.writeVarint32(id)
     itemSerializers[id](buffer, item)
   }

--- a/helpers/serializer.js
+++ b/helpers/serializer.js
@@ -64,7 +64,7 @@ const StaticVariantSerializer = (itemSerializers) => {
     //   ]
     // ]
     // "comment_payout_beneficiaries" was 0 and at some point it got changed
-    // It should still be serialized as a 0 or a integer
+    // It should still be serialized as a 0 or an integer
     // Now the question is, always 0? will need an example transaction to prove otherwise
     if (typeof id === 'string') {
       id = 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-tx",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Create, sign, and broadcast transactions on Hive blockchain",
   "type": "module",
   "module": "./index.js",

--- a/transactions/signTransaction.js
+++ b/transactions/signTransaction.js
@@ -38,7 +38,7 @@ export const transactionDigest = (transaction, chainId = CHAIN_ID) => {
   try {
     Serializer.Transaction(buffer, temp)
   } catch (cause) {
-    throw new Error('Unable to serialize transaction')
+    throw new Error('Unable to serialize transaction: ' + cause)
   }
   buffer.flip()
   const transactionData = Buffer.from(buffer.toBuffer())


### PR DESCRIPTION
```js
// extensions: [
//   [
//     "comment_payout_beneficiaries",
//     {
//       "beneficiaries": [
//         {
//           "account": "vimm",
//           "weight": 1000
//         }
//       ]
//     }
//   ]
// ]
// "comment_payout_beneficiaries" was 0 and at some point it got changed
// It should still be serialized as a 0 or an integer
// Now the question is, always 0? will need an example transaction to prove otherwise
```